### PR TITLE
fix: httpRequest exception

### DIFF
--- a/GTBaseApi.php
+++ b/GTBaseApi.php
@@ -34,7 +34,7 @@ class GTBaseApi
         if ($rep != null) {
             if ('10001' == $rep['code']) {
                 try {
-                    if ($this->gtClient->auth()) {
+                    if ($this->gtClient->getAuthToken()) {
                         $rep = GTHttpManager::httpRequest($this->getUrl($api), $params, $this->buildHead(), $gzip, $method);
                     }
                 } catch (GTException $e) {


### PR DESCRIPTION
Too few arguments to function GTClient::auth(), 0 passed in vendor/getuilaboratory/getui-pushapi-php-client-v2/GTBaseApi.php on line 37 and exactly 2 expected