### PR TITLE
Update GTHttpManager.php for PHP 8.4

### DIFF
--- a/utils/GTHttpManager.php
+++ b/utils/GTHttpManager.php
@@ -19,7 +19,6 @@ class GTHttpManager
         }
         $curl = GTHttpManager::$curls[$url];
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($curl, CURLOPT_BINARYTRANSFER, 1);
         curl_setopt($curl, CURLOPT_USERAGENT, 'GeTui RAS2 PHP/1.0');
         curl_setopt($curl, CURLOPT_FORBID_REUSE, 0);
         curl_setopt($curl, CURLOPT_FRESH_CONNECT, 0);


### PR DESCRIPTION
删除PHP 8.4中废弃的CURLOPT_BINARYTRANSFER常量，此删除不会有任何不利的影响： E_DEPRECATED:Constant CURLOPT_BINARYTRANSFER is deprecated

见：https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated